### PR TITLE
Allow users to change the names of their Voicemaster channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ The list below describes the different "Cogs" of the bot, their associated comma
 
 #### !unlockvm 
 * Unlocks the Voicemaster child you're currently in.
+
+#### !renamevm 
+* Renames your current Voicemaster voice channel.
 </details>
 
 <details>

--- a/src/esportsbot/cogs/AdminCog.py
+++ b/src/esportsbot/cogs/AdminCog.py
@@ -59,7 +59,8 @@ class AdminCog(commands.Cog):
             guild_id=ctx.guild.id,
             actions={
                 "command": ctx.message,
-                "Message": self.STRINGS["channel_cleared"].format(author_mention=ctx.author.mention, message_amount=amount)
+                "Message": self.STRINGS["channel_cleared"].format(author_mention=ctx.author.mention,
+                                                                  message_amount=amount)
             }
         )
 
@@ -178,8 +179,10 @@ class AdminCog(commands.Cog):
                 continue
 
         response_string = str(channel_names).replace("[", "").replace("]", "").strip()
-        await context.send(f"Successfully set the permissions for `{user.display_name}#{user.discriminator}` "
-                           f"in the following channels/categories: `{response_string}`")
+        await context.send(
+            f"Successfully set the permissions for `{user.display_name}#{user.discriminator}` "
+            f"in the following channels/categories: `{response_string}`"
+        )
 
     async def remove_user_permissions(self, guild_channel):
         """

--- a/src/esportsbot/cogs/DefaultRoleCog.py
+++ b/src/esportsbot/cogs/DefaultRoleCog.py
@@ -68,9 +68,13 @@ class DefaultRoleCog(commands.Cog):
             await self.bot.admin_log(
                 guild_id=member.guild.id,
                 actions={
-                    "Cog": self.__class__.__name__,
-                    "Action": self.STRINGS["default_role_join"].format(member_name=member.mention,
-                                                                       role_ids=" ".join(x.mention for x in apply_roles))
+                    "Cog":
+                    self.__class__.__name__,
+                    "Action":
+                    self.STRINGS["default_role_join"].format(
+                        member_name=member.mention,
+                        role_ids=" ".join(x.mention for x in apply_roles)
+                    )
                 }
             )
         else:
@@ -118,7 +122,8 @@ class DefaultRoleCog(commands.Cog):
                     actions={
                         "Cog": self.__class__.__name__,
                         "command": ctx.message,
-                        "Message": self.STRINGS["default_roles_set_log"].format(author_mention=ctx.author.mention, roles=args)
+                        "Message": self.STRINGS["default_roles_set_log"].format(author_mention=ctx.author.mention,
+                                                                                roles=args)
                     }
                 )
             else:

--- a/src/esportsbot/cogs/TwitchCog.py
+++ b/src/esportsbot/cogs/TwitchCog.py
@@ -456,10 +456,13 @@ class TwitchCog(commands.Cog):
 
         # Setup the TwitchListener to listen for /webhook requests.
         app = TwitchApp([(r"/webhook", TwitchListener)])
-        http_server = HTTPServer(app,
-                                 ssl_options={"certfile": f"{os.getenv('SSL_CERT_FILE')}",
-                                              "keyfile": f"{os.getenv('SSL_KEY_FILE')}"}
-                                 )
+        http_server = HTTPServer(
+            app,
+            ssl_options={
+                "certfile": f"{os.getenv('SSL_CERT_FILE')}",
+                "keyfile": f"{os.getenv('SSL_KEY_FILE')}"
+            }
+        )
         http_server.listen(443)
         return http_server, app
 
@@ -631,7 +634,7 @@ class TwitchCog(commands.Cog):
             embed.add_field(name=item.twitch_handle, value=custom_message, inline=False)
         return embed
 
-    @commands.group(name="twitch",  invoke_without_command=True)
+    @commands.group(name="twitch", invoke_without_command=True)
     async def twitch(self, ctx):
         """
         Empty command, purely used to organise subcommands to be under twitch <command> instead of having to ensure name
@@ -640,7 +643,7 @@ class TwitchCog(commands.Cog):
 
         pass
 
-    @twitch.command(name="createhook", aliases=["newhook",  "makehook", "addhook"])
+    @twitch.command(name="createhook", aliases=["newhook", "makehook", "addhook"])
     @commands.has_permissions(administrator=True)
     async def create_new_hook(self, context, bound_channel: discord.TextChannel, hook_name: str):
         """

--- a/src/esportsbot/cogs/VoicemasterCog.py
+++ b/src/esportsbot/cogs/VoicemasterCog.py
@@ -53,7 +53,8 @@ class VoicemasterCog(commands.Cog):
                     DBGatewayActions().delete(vm_slave)
                 elif vm_slave.owner_id == member.id:
                     # It was the owner of the channel that left, transfer ownership.
-                    await before.channel.edit(name=f"{before.channel.members[0].display_name}'s VC")
+                    if not vm_slave.custom_name:
+                        await before.channel.edit(name=f"{before.channel.members[0].display_name}'s VC")
                     vm_slave.owner_id = before.channel.members[0].id
                     DBGatewayActions().update(vm_slave)
 

--- a/src/esportsbot/cogs/VoicemasterCog.py
+++ b/src/esportsbot/cogs/VoicemasterCog.py
@@ -66,7 +66,8 @@ class VoicemasterCog(commands.Cog):
                 guild_id=member.guild.id,
                 channel_id=slave_channel.id,
                 owner_id=member.id,
-                locked=False
+                locked=False,
+                custom_name=False
             )
             DBGatewayActions().create(slave_db_entry)
             await member.move_to(slave_channel)
@@ -281,6 +282,7 @@ class VoicemasterCog(commands.Cog):
                     in_vm_slave.locked = False
                     DBGatewayActions().update(in_vm_slave)
                     await ctx.author.voice.channel.edit(user_limit=0)
+                    await ctx.channel.send(self.STRINGS['success_slave_unlocked'])
                     await self.bot.admin_log(
                         responsible_user=ctx.author,
                         guild_id=ctx.guild.id,
@@ -292,6 +294,44 @@ class VoicemasterCog(commands.Cog):
                     )
                 else:
                     await ctx.channel.send(self.STRINGS['error_already_unlocked'])
+            else:
+                await ctx.channel.send(self.STRINGS['error_not_owned'])
+        else:
+            await ctx.channel.send(self.STRINGS['error_not_in_slave'])
+
+    @commands.command(name="renamevm", aliases=["rename"])
+    async def renamevm(self, ctx):
+        if not ctx.author.voice:
+            await ctx.channel.send(self.STRINGS['error_not_in_slave'])
+            return
+        in_vm_slave = DBGatewayActions().get(
+            VoicemasterSlave,
+            guild_id=ctx.author.guild.id,
+            channel_id=ctx.author.voice.channel.id
+        )
+
+        if in_vm_slave:
+            if in_vm_slave.owner_id == ctx.author.id:
+                command_invoke_string_index = ctx.message.content.index(ctx.invoked_with) + len(ctx.invoked_with)
+                new_name = ctx.message.content[command_invoke_string_index:].strip()
+                if new_name:
+                    await ctx.author.voice.channel.edit(name=new_name)
+                    in_vm_slave.custom_name = True
+                    set_name = new_name
+                else:
+                    await ctx.author.voice.channel.edit(name=f"{ctx.author.display_name}'s VC")
+                    in_vm_slave.custom_name = False
+                    set_name = f"{ctx.author.display_name}'s VC"
+                await self.bot.admin_log(
+                    responsible_user=ctx.author,
+                    guild_id=ctx.guild.id,
+                    actions={
+                        "Cog": self.__class__.__name__,
+                        "command": ctx.message,
+                        "Message": self.STRINGS["log_slave_renamed"].format(mention=ctx.author.mention, new_name=set_name)
+                    }
+                )
+                DBGatewayActions().update(in_vm_slave)
             else:
                 await ctx.channel.send(self.STRINGS['error_not_owned'])
         else:

--- a/src/esportsbot/cogs/VoicemasterCog.py
+++ b/src/esportsbot/cogs/VoicemasterCog.py
@@ -301,6 +301,11 @@ class VoicemasterCog(commands.Cog):
 
     @commands.command(name="renamevm", aliases=["rename"])
     async def renamevm(self, ctx):
+        """
+        Sets the name of the voice channel to the string given after the command. If no string is given, the name is set back
+        to the default name of a voicemaster slave channel.
+        :param ctx: The context of the command.
+        """
         if not ctx.author.voice:
             await ctx.channel.send(self.STRINGS['error_not_in_slave'])
             return

--- a/src/esportsbot/cogs/VoicemasterCog.py
+++ b/src/esportsbot/cogs/VoicemasterCog.py
@@ -96,9 +96,12 @@ class VoicemasterCog(commands.Cog):
                     responsible_user=ctx.author,
                     guild_id=ctx.guild.id,
                     actions={
-                        "Cog": self.__class__.__name__,
-                        "command": ctx.message,
-                        "Message": self.STRINGS["log_vm_master_added"].format(
+                        "Cog":
+                        self.__class__.__name__,
+                        "command":
+                        ctx.message,
+                        "Message":
+                        self.STRINGS["log_vm_master_added"].format(
                             author=ctx.author.mention,
                             channel=new_vm_master_channel.name,
                             channel_id=new_vm_master_channel.id
@@ -161,8 +164,10 @@ class VoicemasterCog(commands.Cog):
                     responsible_user=ctx.author,
                     guild_id=ctx.guild.id,
                     actions={
-                        "Cog": self.__class__.__name__,
-                        "command": ctx.message,
+                        "Cog":
+                        self.__class__.__name__,
+                        "command":
+                        ctx.message,
                         "Message":
                         self.STRINGS['log_vm_master_removed'].format(
                             mention=ctx.author.guild.id,
@@ -333,7 +338,8 @@ class VoicemasterCog(commands.Cog):
                     actions={
                         "Cog": self.__class__.__name__,
                         "command": ctx.message,
-                        "Message": self.STRINGS["log_slave_renamed"].format(mention=ctx.author.mention, new_name=set_name)
+                        "Message": self.STRINGS["log_slave_renamed"].format(mention=ctx.author.mention,
+                                                                            new_name=set_name)
                     }
                 )
                 DBGatewayActions().update(in_vm_slave)

--- a/src/esportsbot/cogs/VotingCog.py
+++ b/src/esportsbot/cogs/VotingCog.py
@@ -166,7 +166,7 @@ class VotingCog(commands.Cog):
         await voting_menu.update_message()
         self.add_or_update_db(voting_menu.id)
 
-    @command_group.command(name="delete-poll",  aliases=["delete", "del"])
+    @command_group.command(name="delete-poll", aliases=["delete", "del"])
     async def delete_poll(self, context: commands.Context, menu_id: int):
         """
         Delete a poll .

--- a/src/esportsbot/lib/client.py
+++ b/src/esportsbot/lib/client.py
@@ -49,11 +49,15 @@ class EsportsBot(commands.Bot):
         print("[EsportsBot] Shutting down...")
         await self.logout()
 
-    async def admin_log(self,
-                        guild_id: int,
-                        actions: Dict[str, Any],
-                        responsible_user: Union[Member, User] = None,
-                        colour=None):
+    async def admin_log(
+        self,
+        guild_id: int,
+        actions: Dict[str,
+                      Any],
+        responsible_user: Union[Member,
+                                User] = None,
+        colour=None
+    ):
         guild_settings = DBGatewayActions().get(GuildInfo, guild_id=guild_id)
         if not guild_settings or not guild_settings.log_channel_id:
             return

--- a/src/esportsbot/models.py
+++ b/src/esportsbot/models.py
@@ -97,6 +97,7 @@ class VoicemasterSlave(base):
     channel_id = Column(BigInteger, nullable=False)
     owner_id = Column(BigInteger, nullable=False)
     locked = Column(Boolean, nullable=False)
+    custom_name = Column(Boolean, nullable=False)
 
 
 class TwitchInfo(base):

--- a/src/esportsbot/user_strings.toml
+++ b/src/esportsbot/user_strings.toml
@@ -643,6 +643,7 @@ log_vm_masters_cleared = "{mention} has removed all VM masters"
 log_vm_slaves_cleared = "{mention} has removed all VM slaves"
 log_slave_locked = "{mention} has locked their VM slave"
 log_slave_unlocked = "{mention} has unlocked their VM slave"
+log_slave_renamed = "{mention} has renamed their VM slave to `{new_name}`"
 
 [twitch]
 generic_error = "There was an error while trying to add `{channel}` as a tracked channel"

--- a/src/esportsbot/user_strings.toml
+++ b/src/esportsbot/user_strings.toml
@@ -230,6 +230,11 @@ help_string = "Unlocks your current Voicemaster voice channel."
 description = "If you are in a Voicemaster child channel and if you own the channel, it will remove the user-count limit."
 readme_url = "https://github.com/FragSoc/esports-bot#unlockvm"
 
+[help.renamevm]
+help_string = "Renames your current Voicemaster voice channel."
+description = "If you are in a Voicemaster child channel and if you own the channel, it will change the name to the name given. If no name is given, it gets reset to the default name."
+readme_url = "https://github.com/FragSoc/esports-bot#renamevm"
+
 [help.clear]
 help_string = "Deletes the given number of messages. Defaults to 5 messages."
 usage = "<number of messages>"


### PR DESCRIPTION
Added a new command to allow users to change the name of the their VCs. To ensure that when the owner leaves the channel isn't renamed, a new field was added to the DB table for VM slaves to indicate if a VC has had a custom name set.

This change resolves #96